### PR TITLE
Enable SQL Logger

### DIFF
--- a/src/Soql/ConnectionWrapper.php
+++ b/src/Soql/ConnectionWrapper.php
@@ -22,6 +22,7 @@ use function json_encode;
 use function key;
 use function sprintf;
 use function uniqid;
+use const JSON_PRETTY_PRINT;
 
 class ConnectionWrapper extends Connection
 {
@@ -214,10 +215,10 @@ class ConnectionWrapper extends Connection
                 'request' => [
                     'method' => $request->getMethod(),
                     'uri'    => (string) $request->getUri(),
-                    'header' => json_encode($request->getHeaders()),
-                    'body'   => json_encode($request->getBody()->getContents()),
+                    'header' => $request->getHeaders(),
+                    'body'   => json_decode($request->getBody()->getContents()),
                 ],
-            ]));
+            ], JSON_PRETTY_PRINT));
         }
 
         $request->getBody()->rewind();
@@ -228,10 +229,10 @@ class ConnectionWrapper extends Connection
             $logger->startQuery(json_encode([
                 'response' => [
                     'statusCode' => $response->getStatusCode(),
-                    'header'     => json_encode($response->getHeaders()),
-                    'body'       => $response->getBody()->getContents(),
+                    'header'     => $response->getHeaders(),
+                    'body'       => json_decode($response->getBody()->getContents()),
                 ],
-            ]));
+            ], JSON_PRETTY_PRINT));
             $logger->stopQuery();
         }
 

--- a/src/Soql/ConnectionWrapper.php
+++ b/src/Soql/ConnectionWrapper.php
@@ -9,7 +9,8 @@ use Doctrine\DBAL\ConnectionException;
 use Doctrine\DBAL\Exception\InvalidArgumentException;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Psr7\Request;
-use GuzzleHttp\Psr7\Response;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
 use Webmozart\Assert\Assert;
 use function array_filter;
 use function array_key_exists;
@@ -80,7 +81,6 @@ class ConnectionWrapper extends Connection
         $response     = $this->send($request);
         $responseBody = json_decode($response->getBody()->getContents(), true);
 
-        var_dump($responseBody['success']);
         if ($responseBody['success'] !== true) {
             throw OperationFailed::insertFailed($data);
         }
@@ -204,7 +204,7 @@ class ConnectionWrapper extends Connection
         ];
     }
 
-    private function send(Request $request) : Response
+    private function send(RequestInterface $request) : ResponseInterface
     {
         $logger = $this->_config->getSQLLogger();
         $http   = $this->getHttpClient();
@@ -226,10 +226,13 @@ class ConnectionWrapper extends Connection
                 'response' => [
                     'statusCode' => $response->getStatusCode(),
                     'header'     => json_encode($response->getHeaders()),
+                    'body'       => $response->getBody()->getContents(),
                 ],
             ]));
             $logger->stopQuery();
         }
+
+        $response->getBody()->rewind();
 
         return $response;
     }

--- a/src/Soql/ConnectionWrapper.php
+++ b/src/Soql/ConnectionWrapper.php
@@ -12,6 +12,7 @@ use GuzzleHttp\Psr7\Request;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Webmozart\Assert\Assert;
+use const JSON_PRETTY_PRINT;
 use function array_filter;
 use function array_key_exists;
 use function array_map;
@@ -22,7 +23,6 @@ use function json_encode;
 use function key;
 use function sprintf;
 use function uniqid;
-use const JSON_PRETTY_PRINT;
 
 class ConnectionWrapper extends Connection
 {
@@ -207,16 +207,18 @@ class ConnectionWrapper extends Connection
 
     private function send(RequestInterface $request) : ResponseInterface
     {
-        $logger = $this->_config->getSQLLogger();
-        $http   = $this->getHttpClient();
+        $requestId = uniqid('requestId', false);
+        $logger    = $this->_config->getSQLLogger();
+        $http      = $this->getHttpClient();
 
         if ($logger) {
             $logger->startQuery(json_encode([
                 'request' => [
-                    'method' => $request->getMethod(),
-                    'uri'    => (string) $request->getUri(),
-                    'header' => $request->getHeaders(),
-                    'body'   => json_decode($request->getBody()->getContents()),
+                    'requestId' => $requestId,
+                    'method'    => $request->getMethod(),
+                    'uri'       => (string) $request->getUri(),
+                    'header'    => $request->getHeaders(),
+                    'body'      => json_decode($request->getBody()->getContents()),
                 ],
             ], JSON_PRETTY_PRINT));
         }
@@ -228,6 +230,7 @@ class ConnectionWrapper extends Connection
         if ($logger) {
             $logger->startQuery(json_encode([
                 'response' => [
+                    'requestId'  => $requestId,
                     'statusCode' => $response->getStatusCode(),
                     'header'     => $response->getHeaders(),
                     'body'       => json_decode($response->getBody()->getContents()),

--- a/src/Soql/ConnectionWrapper.php
+++ b/src/Soql/ConnectionWrapper.php
@@ -118,9 +118,9 @@ class ConnectionWrapper extends Connection
     private function addToBatchList(Request $request, array $refs) : void
     {
         $command = [
-            'body' => $request->getBody()->getContents(),
+            'body' => json_decode($request->getBody()->getContents(), true),
             'method' => $request->getMethod(),
-            'url' => $request->getUri(),
+            'url' => (string) $request->getUri(),
         ];
 
         if ($refs !== []) {
@@ -218,7 +218,7 @@ class ConnectionWrapper extends Connection
                     'method'    => $request->getMethod(),
                     'uri'       => (string) $request->getUri(),
                     'header'    => $request->getHeaders(),
-                    'body'      => json_decode($request->getBody()->getContents()),
+                    'body'      => json_decode($request->getBody()->getContents(), true),
                 ],
             ], JSON_PRETTY_PRINT));
         }
@@ -233,7 +233,7 @@ class ConnectionWrapper extends Connection
                     'requestId'  => $requestId,
                     'statusCode' => $response->getStatusCode(),
                     'header'     => $response->getHeaders(),
-                    'body'       => json_decode($response->getBody()->getContents()),
+                    'body'       => json_decode($response->getBody()->getContents(), true),
                 ],
             ], JSON_PRETTY_PRINT));
             $logger->stopQuery();

--- a/src/Soql/ConnectionWrapper.php
+++ b/src/Soql/ConnectionWrapper.php
@@ -215,9 +215,12 @@ class ConnectionWrapper extends Connection
                     'method' => $request->getMethod(),
                     'uri'    => (string) $request->getUri(),
                     'header' => json_encode($request->getHeaders()),
+                    'body'   => json_encode($request->getBody()->getContents()),
                 ],
             ]));
         }
+
+        $request->getBody()->rewind();
 
         $response = $http->send($request);
 


### PR DESCRIPTION
It's handy to be able to use same SQL Loggers supported by Doctrine.
In SOQL make more sense to log API Requests and Responses.

<details>
Co-authored-by: Jefersson Nathan <malukenho.dev@gmail.com><br>
Signed-off-by: Alexandre Eher <alexandre@eher.com.br>
</details>