### PR TITLE
Reuse Access Token after the first authentication

### DIFF
--- a/tests/Soql/Factory/HttpAccessTokenFactoryTest.php
+++ b/tests/Soql/Factory/HttpAccessTokenFactoryTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CodeliciaTest\Soql;
+
+use Codelicia\Soql\Factory\HttpAccessTokenFactory;
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
+
+final class HttpAccessTokenFactoryTest extends TestCase
+{
+    /** @test */
+    public function it_should_reuse_access_token_after_authentication() : void
+    {
+        $factory = new HttpAccessTokenFactory(
+            'salesforceInstance',
+            'consumerKey',
+            'consumerSecret',
+            'username',
+            'password'
+        );
+
+        $client = $this->createMock(ClientInterface::class);
+        $client->expects(self::once())->method('request')->willReturn(
+            new Response(200, [], '{"access_token": "s3Gr3D0"}')
+        );
+
+        $factory->__invoke($client);
+        $factory->__invoke($client);
+        $factory->__invoke($client);
+        $factory->__invoke($client);
+        $factory->__invoke($client);
+    }
+}


### PR DESCRIPTION
Once we do the Oauth authentication we should just reuse the access
token instead of re-authenticate every time.