### PR TITLE
Fix issue when querying data from salesforce

### DIFF
--- a/src/Soql/QueryBuilder.php
+++ b/src/Soql/QueryBuilder.php
@@ -8,7 +8,9 @@ use Assert\Assertion;
 use BadMethodCallException;
 use Doctrine\DBAL\Query\QueryBuilder as DbalQueryBuilder;
 use function implode;
+use function is_string;
 use function sprintf;
+use function urlencode;
 
 final class QueryBuilder extends DbalQueryBuilder
 {
@@ -31,6 +33,16 @@ final class QueryBuilder extends DbalQueryBuilder
         );
 
         return $this->addSelect($query);
+    }
+
+    /** {@inheritDoc} */
+    public function setParameter($key, $value, $type = null)
+    {
+        if (is_string($value)) {
+            $value = urlencode($value);
+        }
+
+        return parent::setParameter($key, $value, $type);
     }
 
     /** {@inheritDoc} */

--- a/tests/Soql/QueryBuilderTest.php
+++ b/tests/Soql/QueryBuilderTest.php
@@ -51,6 +51,25 @@ final class QueryBuilderTest extends TestCase
     }
 
     /** @test */
+    public function it_should_urlencode_string_parameters() : void
+    {
+        $phone = '+(000) 0000-0000';
+        $queryBuilder = (new QueryBuilder($this->createMock(Connection::class)))
+            ->setParameter('phone', $phone);
+
+        self::assertSame(urlencode($phone), $queryBuilder->getParameter('phone'));
+    }
+
+    /** @test */
+    public function it_should_not_urlencode_non_string_parameters() : void
+    {
+        $queryBuilder = (new QueryBuilder($this->createMock(Connection::class)))
+            ->setParameter('age', 12);
+
+        self::assertSame(12, $queryBuilder->getParameter('age'));
+    }
+
+    /** @test */
     public function it_should_deny_left_join_method_call() : void
     {
         $queryBuilder = new QueryBuilder($this->createMock(Connection::class));


### PR DESCRIPTION
The query parameters need to be URL-encoded so that the salesforce API
doesn't break.