### PR TITLE
Fix class namespace to be compatible with PSR-4

### DIFF
--- a/tests/Soql/Factory/HttpAccessTokenFactoryTest.php
+++ b/tests/Soql/Factory/HttpAccessTokenFactoryTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace CodeliciaTest\Soql;
+namespace CodeliciaTest\Soql\Factory;
 
 use Codelicia\Soql\Factory\HttpAccessTokenFactory;
 use GuzzleHttp\ClientInterface;


### PR DESCRIPTION
# Changed log

- Adding the `CodeliciaTest\Soql\Factory` namespace to be compatible with `PSR-4` autoloading.