### PR TITLE
Remove useless GuzzleHttp\Psr7\Response namespace

### DIFF
--- a/tests/Soql/ConnectionWrapperTest.php
+++ b/tests/Soql/ConnectionWrapperTest.php
@@ -9,7 +9,6 @@ use Codelicia\Soql\Factory\AuthorizedClientFactory;
 use Codelicia\Soql\QueryBuilder;
 use Codelicia\Soql\SoqlDriver;
 use GuzzleHttp\ClientInterface;
-use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;


### PR DESCRIPTION
# Changed log

- Remove `use GuzzleHttp\Psr7\Response;` namespace because it's unnecessary.