### PR TITLE
Allow upsert query with external id

### DIFF
--- a/src/Soql/OperationFailed.php
+++ b/src/Soql/OperationFailed.php
@@ -30,4 +30,10 @@ final class OperationFailed extends RuntimeException implements SoqlException
     {
         return new self(sprintf('Transaction failed with messages: %s', json_encode($errors, JSON_THROW_ON_ERROR)));
     }
+
+    /** @param mixed[] $payload */
+    public static function upsertFailed(array $payload): self
+    {
+        return new self(sprintf('Upsert failed with payload %s', json_encode($payload)));
+    }
 }

--- a/tests/Soql/ConnectionWrapperTest.php
+++ b/tests/Soql/ConnectionWrapperTest.php
@@ -195,6 +195,28 @@ final class ConnectionWrapperTest extends TestCase
         $this->connection->commit();
     }
 
+    /** @test */
+    public function upsert_with_no_transaction(): void
+    {
+        $this->client->expects(self::once())->method('send')
+            ->with(self::assertHttpHeaderIsPropagated())
+            ->willReturn($this->response);
+
+        $this->response->expects(self::once())->method('getBody')->willReturn($this->stream);
+        $this->response->expects(self::once())->method('getStatusCode')->willReturn(201);
+
+        $this->stream->expects(self::once())->method('rewind');
+
+        $this->connection->upsert(
+            'User',
+            'ExternalId__c',
+            '12345',
+            ['Name' => 'Pay as you go Opportunity'],
+            [],
+            ['X-Unit-Testing' => 'Yes']
+        );
+    }
+
     private static function assertHttpHeaderIsPropagated(): Callback
     {
         return self::callback(static function (Request $request) : bool {


### PR DESCRIPTION
We would like the possibility do doing upsert query to the Salesforce API  using an external Id

https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/dome_upsert.htm