### PR TITLE
Allow for the connection to have a middleware.

### DIFF
--- a/src/Soql/ConnectionWrapper.php
+++ b/src/Soql/ConnectionWrapper.php
@@ -367,6 +367,6 @@ class ConnectionWrapper extends Connection
     {
         $this->connect();
 
-        return $this->_conn->getHttpClient();
+        return $this->_conn->getNativeConnection();
     }
 }

--- a/src/Soql/SoqlConnection.php
+++ b/src/Soql/SoqlConnection.php
@@ -30,6 +30,11 @@ class SoqlConnection implements Connection
         return $this->authorizedClientFactory->__invoke();
     }
 
+    public function getNativeConnection(): ClientInterface
+    {
+        return $this->authorizedClientFactory->__invoke();
+    }
+
     /** {@inheritDoc} */
     public function query(string $sql): ResultInterface
     {


### PR DESCRIPTION
When using a middleware such as the one the `symfony/doctrine-bridge` installs for the connection the soql driver fails by trying to call `_conn` on a wrapped connection. This line `return $this->_conn->getHttpClient();`
The middleware.
https://github.com/symfony/doctrine-bridge/blob/6.1/Middleware/Debug/Connection.php

Honestly I don't know how to remove the middleware but it is fairly simple to make the driver play nice with middleware by establishing that the http client is the "native connection" for the driver. That is what this change tries to achieve.

Maybe the `getHttpClient()` method on the `SoqlConnection` class can be removed as is a duplicate of `getNativeConnection()` but I leave that decision to the maintainers for keeping compatibility.