### PR TITLE
Implement ServerInfoAwareConnection.

### DIFF
--- a/src/Soql/SoqlConnection.php
+++ b/src/Soql/SoqlConnection.php
@@ -6,14 +6,14 @@ namespace Codelicia\Soql;
 
 use Codelicia\Soql\Driver\Result;
 use Codelicia\Soql\Factory\AuthorizedClientFactory;
-use Doctrine\DBAL\Driver\Connection;
 use Doctrine\DBAL\Driver\Result as ResultInterface;
+use Doctrine\DBAL\Driver\ServerInfoAwareConnection;
 use GuzzleHttp\ClientInterface;
 use PDO;
 
 use function addslashes;
 
-class SoqlConnection implements Connection
+class SoqlConnection implements ServerInfoAwareConnection
 {
     public function __construct(private AuthorizedClientFactory $authorizedClientFactory)
     {
@@ -78,5 +78,10 @@ class SoqlConnection implements Connection
     public function rollBack(): bool
     {
         return true;
+    }
+
+    public function getServerVersion(): string
+    {
+        return $this->getHttpClient()->getConfig('apiVersion');
     }
 }


### PR DESCRIPTION
Another requirement for being friendly with middleware connections.
Another reason is that not implementint the interface is deprecated so this should be done sooner or later.
https://github.com/doctrine/dbal/blob/3.5.x/src/Connection.php#L480

I'm grabbing the apiVersion from the http client but I'm not sure if this can be simplified.

Signed-off-by: Rodrigo Aguilera <hi@rodrigoaguilera.net>