### PR TITLE
Determine correct apiVersion when is passed as a driverOption.

### DIFF
--- a/src/Soql/ConnectionWrapper.php
+++ b/src/Soql/ConnectionWrapper.php
@@ -359,7 +359,7 @@ class ConnectionWrapper extends Connection
 
     private function apiVersion(): string
     {
-        return $this->getParams()['apiVersion'];
+        return $this->getParams()['apiVersion'] ?? $this->getParams()['driverOptions']['apiVersion'];
     }
 
     /** @throws Exception */


### PR DESCRIPTION
One of my latest chenges introduced the ability to pass configuration params as `driverOptions` but then I broke `getApiVersion()` on the wrapper. This attempts to fix that.