### PR TITLE
chore(ci): use composer tasks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: Run CI
 
-on: [push, pull_request]
+on: push
 
 jobs:
   build:
@@ -10,33 +10,25 @@ jobs:
     strategy:
       matrix:
         php: ['8.1', '8.2']
-        dependencies: ['normal', 'authoritative']
 
     steps:
     - uses: actions/checkout@v3
 
     - name: Install dependencies
-      if: matrix.dependencies == 'normal'
-      run: composer install --prefer-dist
-      env:
-        COMPOSER_ROOT_VERSION: dev-master
-
-    - name: Install dependencies
-      if: matrix.dependencies == 'authoritative'
       run: composer install --prefer-dist --classmap-authoritative
-      env:
-        COMPOSER_ROOT_VERSION: dev-master
 
-    - name: Run Phpunit
-      run: composer run phpunit
+    - name: Check code style
+      run: composer run style-check -- -q --report=checkstyle | ./vendor/bin/cs2pr
 
-    - name: Run Infection
+    - name: Run unit tests
+      run: composer run test-unit
+
+    - name: Run mutation tests
       run: |
-        XDEBUG_MODE=coverage ./vendor/bin/phpunit --coverage-xml cov --log-junit=cov/result.junit.xml
-        ./vendor/bin/infection --coverage=cov
-
-    - name: Run PhpCs
-      run: ./vendor/bin/phpcs -q --report=checkstyle | ./vendor/bin/cs2pr
+        composer run test-unit -- --coverage-xml cov --log-junit=cov/result.junit.xml
+        composer run test-mutation -- --coverage=cov
+      env:
+        XDEBUG_MODE: coverage
 
     - name: Check dependency usage
-      run: ./vendor/bin/composer-require-checker check ./composer.json
+      run: composer run composer-check

--- a/composer.json
+++ b/composer.json
@@ -52,16 +52,24 @@
         }
     },
     "scripts": {
-        "phpcs": "vendor/bin/phpcs",
-        "phpcbf": "vendor/bin/phpcbf",
-        "infection": "vendor/bin/infection",
-        "phpunit": "php -dzend.assertions=1 vendor/bin/phpunit",
-        "require-checker": "vendor/bin/composer-require-checker check composer.json",
+        "composer-check": "composer-require-checker check composer.json",
+        "style-check": "phpcs",
+        "style-fix": "phpcbf",
+        "test-mutation": "infection",
+        "test-unit": "@php -dzend.assertions=1 vendor/bin/phpunit",
         "test": [
-            "@phpcs",
-            "@phpunit",
-            "@infection",
-            "@require-checker"
+            "@style-check",
+            "@test-unit",
+            "@test-mutation",
+            "@composer-check"
         ]
+    },
+    "scripts-descriptions": {
+        "style-check": "Check violations on code style",
+        "style-fix": "Fix violations on code style",
+        "test": "Run all the tests",
+        "test-mutation": "Run mutation tests",
+        "test-unit": "Run unit tests",
+        "composer-check": "Analyze composer dependencies"
     }
 }


### PR DESCRIPTION
The main commands used in the project are centralized on composer. Those tasks can be used in development and on githug actions (CI).

It's possible to list all available tasks with:

$ composer run --list

And then you can run with:

$ composer run <task>

For instance to run unit tests:

$ composer run test-unit

Or to run all the tests:

$ composer run test